### PR TITLE
Remove erroneous reference to JSON property names.

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ service-api.com/app-setups
 ```
 
 Downcase attributes as well, but use underscore separators so that
-attribute names are valid JSON keys, e.g.:
+attribute names can be typed without quotes in JavaScript, e.g.:
 
 ```
 "service_class": "first"


### PR DESCRIPTION
JSON attributes names can legally contain a dash, they're just harder to type in JavaScript code.  Let's call a spade a spade here and admit that's why underscore separators are the standard.
