### PR TITLE
remove quotes from "service_class"

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Downcase attributes as well, but use underscore separators so that
 attribute names can be typed without quotes in JavaScript, e.g.:
 
 ```
-"service_class": "first"
+service_class: "first"
 ```
 
 ### Nest foreign key relations


### PR DESCRIPTION
Since the guidance for attribute names is to downcase and use underscores so that the attribute names can be used without quotes, this just changes the example given to show that behavior.

The quotes being present are still valid JSON / JavaScript, but since the guidance leads to attribute names that can be used without them, having the example not include the quotes shows the benefit.
