### PR TITLE
Responding for non-TLS requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ Require TLS to access the API, without exception. It’s not worth trying
 to figure out or explain when it is OK to use TLS and when it’s not.
 Just require TLS for everything.
 
+Respond to non-TLS requests with `403 Forbidden`.  Redirects are 
+discouraged since they allow sloppy/bad client behaviour without 
+providing any clear gain.  Clients that rely on redirects double up on 
+server traffic and render TLS useless since sensitive data will already
+ have been exposed during the first call.
+
 #### Version with Accepts header
 
 Version the API from the start. Use the `Accepts` header to communicate


### PR DESCRIPTION
Do we consider it best practice to respond to non-TLS requests with a 403?  

The other alternative that I am aware of is to redirect to a secured version of the URL.  But I don't much like that approach since it makes it easy for a sloppily written client to continue doing bad things.

Could we add recommendation to the Require TLS block?  Perhaps:

Enforce good client-behaviour by responding to insecure requests with a 403 status code. Redirects are discouraged since they allow client code to effectively ignore the issue, doubling up on server traffic and rendering TLS useless since sensitive data will already have been exposed by the first call.
