### PR TITLE
Added use of HTTP 400 Bad Request for failed validation on request body content

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -4,3 +4,4 @@
 * Mark McGranaghan <mmcgrana@gmail.com>
 * Jamu Kakar <jkakar@kakar.ca>
 * Jonathan Roes <jroes@jroes.net>
+* Suhas Chatekar <suhas.chatekar@gmail.com>

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Pay attention to the use of authentication and authorization error codes:
 
 Return suitable codes to provide additional information when there are errors:
 
+* `400 Bad Request` : One or more validations have failed on the data sent in request. Use response body to tell more about validation errors. 
 * `422 Unprocessable Entity`: Your request was understood, but contained invalid parameters
 * `429 Too Many Requests`: You have been rate-limited, retry later
 * `500 Internal Server Error`: Something went wrong on the server, check status site and/or report the issue


### PR DESCRIPTION
I have been using `400 Bad Request` status code to indicate validation failures on the incoming `POST`/`PUT` requests. I think this works quite well and needs a mention. Happy to elaborate with examples if needed. 
