### PR TITLE
Add a missing dot

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ Serialize foreign key references with a nested object, e.g.:
 }
 ```
 
-Instead of e.g:
+Instead of e.g.:
 
 ```javascript
 {


### PR DESCRIPTION
Add a missing dot:

`e.g` -> `e.g.`