### PR TITLE
readme typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Agradecemos también [contribuciones](CONTRIBUTING.md) a la versión inglesa de 
   *  [Separar responsabilidades](#separar-responsabilidades)
   *  [Conexiones seguras requeridas](#conexiones-seguras-requeridas)
   *  [Versionado con la cabecera Accepts requerido](#versionado-con-la-cabecera-accepts-requerido)
-  *  [Soportar ETags para cacheado](#soportar-etags-para-cacheado)
+  *  [Soportar ETags para el cacheado](#soportar-etags-para-el-cacheado)
   *  [Proporcionar identificadores de petición para introspección](#Proporcionar-identificadores-de-petición-para-introspeccion)
   *  [Dividir respuestas largas en varias peticiones usando rangos](#dividir-respuestas-largas-en-varias-peticiones-usando-rangos)
 * [Peticiones](#peticiones)
@@ -74,12 +74,9 @@ Es mejor especificar la versión en las cabeeras, junto a otros metadatos, usand
 Accept: application/vnd.heroku+json; version=3
 ```
 
-#### Support ETags for Caching
+#### Soportar ETags para el cacheado
 
-Include an `ETag` header in all responses, identifying the specific
-version of the returned resource. This allows users to cache resources
-and use requests with this value in the `If-None-Match` header to determine
-if the cache should be updated.
+Incluye una cabecera `ETag` en todas las respuestas, identificando la versión específica del recurso retornado. Esto permite a los usuarios cachear recursos y usar peticiones con este valor en la cabecera `If-None-Match` para especificar si la caché debe ser actualizada.
 
 #### Provide Request-Ids for Introspection
 

--- a/README.md
+++ b/README.md
@@ -209,18 +209,15 @@ $ curl https://service.com/apps/www-prod
 
 No aceptes sólo nombres omitiendo los identificadores.
 
-#### Minimize path nesting
+#### Minimizar anidado de rutas
 
-In data models with nested parent/child resource relationships, paths
-may become deeply nested, e.g.:
+En modelos de datos con relaciones entre recursos padre/hijo, las rutas pueden acabar estando muy anidadas, p.e.:
 
 ```
 /orgs/{org_id}/apps/{app_id}/dynos/{dyno_id}
 ```
 
-Limit nesting depth by preferring to locate resources at the root
-path. Use nesting to indicate scoped collections. For example, for the
-case above where a dyno belongs to an app belongs to an org:
+Limita el anidamiento excesivo poniendo recursos en el raíz de la ruta. Usa anidado para indicar colecciones. Por ejemplo, para el caso anterior en que un _dyno_ pertenece a una app, que pertenece a una organización:
 
 ```
 /orgs/{org_id}

--- a/README.md
+++ b/README.md
@@ -62,18 +62,13 @@ Idealmente, rechaza cualquier petición sin TLS sin responder a peticiones HTTP 
 
 Las redirecciones están desaconsejadas ya que permiten a los clientes tener comportamientos incorrectos/chapuceros sin ofrecer ninguna ventaja clara. Los clientes que dependen de las redirecciones duplican el tráfico del servidor and hacen que el TLS sea inutil ya que la información sensible ya ha sido expuesta durante la primera llamada.
 
-#### Require Versioning in the Accepts Header
+#### Versionado con la cabecera Accepts requerido
 
-Versioning and the transition between versions can be one of the more
-challenging aspects of designing and operating an API. As such, it is best to
-start with some mechanisms in place to mitigate this from the start.
+El versionado y la transición entre versiones puede ser uno de los aspectos más difíciles en el diseño y mantenimiento de un API. Por eso, es mejor empezar con mecanismos para facilitarlo desde el principio.
 
-To prevent surprise, breaking changes to users, it is best to require a version
-be specified with all requests. Default versions should be avoided as they are
-very difficult, at best, to change in the future.
+Para evitar sorpresas, cambios incompatibles para los usuarios, es mejor que la versión sea requerida en todas las peticiones. Las versiones por defecto deben ser evitadas ya que, en el mejor de los casos, son muy difíciles de cambiar en el futuro.
 
-It is best to provide version specification in the headers, with other
-metadata, using the `Accept` header with a custom content type, e.g.:
+Es mejor especificar la versión en las cabeeras, junto a otros metadatos, usando la cabecera `Accept` junto con un _content type_ personalizado, por ejemplo:
 
 ```
 Accept: application/vnd.heroku+json; version=3

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Guía de diseño de APIs HTTPGuide
+# Guía de diseño de APIs HTTP
 
 ## Introducción
 

--- a/README.md
+++ b/README.md
@@ -111,12 +111,9 @@ Retorna códigos adecuados para ofrecer información adicional cuando ocurran er
 
 Consulta la [especificación de códigos de respuesta HTTP](https://tools.ietf.org/html/rfc7231#section-6) para una guía sobre los códigos de estado para errores de usuario o de servidor.
 
-#### Provide full resources where available
+#### Proporcionar recursos completos si están disponibles
 
-Provide the full resource representation (i.e. the object with all
-attributes) whenever possible in the response. Always provide the full
-resource on 200 and 201 responses, including `PUT`/`PATCH` and `DELETE`
-requests, e.g.:
+Incluye en la respuesta la representación completa del recurso (p.e. el objeto con todos sus atributos) siempre que sea posible. Siempre incluye el recurso completo en respuestas `200` y `201`, incluidas peticiones tipo `PUT`/`PATCH` y `DELETE`, p.e.:
 
 ```bash
 $ curl -X DELETE \  
@@ -133,8 +130,7 @@ Content-Type: application/json;charset=utf-8
 }
 ```
 
-202 responses will not include the full resource representation,
-e.g.:
+Las respuetas `202` no deben incluir la representaciín completa del recurso, p.e.:
 
 ```bash
 $ curl -X DELETE \  

--- a/README.md
+++ b/README.md
@@ -1,23 +1,17 @@
-# HTTP API Design Guide
+# Guía de diseño de APIs HTTPGuide
 
-## Introduction
+## Introducción
 
-This guide describes a set of HTTP+JSON API design practices, originally
-extracted from work on the [Heroku Platform API](https://devcenter.heroku.com/articles/platform-api-reference).
+Esta guía describe un conjunto de buenas prácticas para el diseño de APIs HTTP+JSON originalmente extraído del trabajo en el API de la [plataforma Heroku](https://devcenter.heroku.com/articles/platform-api-reference).
 
-This guide informs additions to that API and also guides new internal
-APIs at Heroku. We hope it’s also of interest to API designers
-outside of Heroku.
+Esta guía incluye añadidos a ese API y también sirve de guía para nuevas APIs internas en Heroku. Esteramos que sea de interés a los diseñadores de APIs que no son de Heroku.
 
-Our goals here are consistency and focusing on business logic while
-avoiding design bikeshedding. We’re looking for _a good, consistent,
-well-documented way_ to design APIs, not necessarily _the only/ideal
-way_.
+Los objetivos que nos hemos marcado son consistencia y foco en la lógica de negocio, a la vez que evitamos centrarnos en detalles supérfluos (_N.T. el término en ingles es "design bikeshedding" explicado en [este artículo](http://es.wikipedia.org/wiki/Ley_de_Parkinson_de_la_trivialidad))._
+Buscamos un _método bueno, consistente y bien documentado_ para el diseño de APIs, aunque no necesariamente _el método único o ideal_.
 
-We assume you’re familiar with the basics of HTTP+JSON APIs and won’t
-cover all of the fundamentals of those in this guide.
+Asumimos que los conceptos básicos de APIs HTTP+JSON son familiares para tí, así que no entraremos en sus fundamentos en esta guía.
 
-We welcome [contributions](CONTRIBUTING.md) to this guide.
+Agradecemos también [contribuciones](CONTRIBUTING.md) a la versión inglesa de esta guía o a su traducción al castellano.
 
 ## Contents
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Agradecemos también [contribuciones](CONTRIBUTING.md) a la versión inglesa de 
 * [Respuestas](#respuestas)
   *  [Proporcionar identificadores únicos (UUIDs) de recursos](#proporcionar-identificadores-unicos-uuids-de-recursos)
   *  [Proporcionar fechas y horas (timestamps) estándar](#proporcionar-fechas-y-horas-timestamps-estandar)
-  *  [Usar horas en UTC formateadas usando ISO8601](#usar-horas-en-utc-formateadas-usando-ISO8601)
+  *  [Usar horas en UTC con formato ISO8601](#usar-horas-en-utc-con-formato-ISO8601)
   *  [Anidar relaciones de clave foránea](#anidar-relaciones-de-clave-foranea)
   *  [Generar errores estructurados](#generar-errores-estructurados)
   *  [Mostrar el estado del límite de peticiones](#mostrar-el-estado-del-limite-de-peticiones)
@@ -227,25 +227,21 @@ Limita el anidamiento excesivo poniendo recursos en el raíz de la ruta. Usa ani
 /dynos/{dyno_id}
 ```
 
-### Responses
+### Respuestas
 
-#### Provide resource (UU)IDs
+#### Proporcionar identificadores únicos (UUIDs) de recursos
 
-Give each resource an `id` attribute by default. Use UUIDs unless you
-have a very good reason not to. Don’t use IDs that won’t be globally
-unique across instances of the service or other resources in the
-service, especially auto-incrementing IDs.
+Dale a cada recurso un atributo `id` por defecto. Usa Identificadores Únicos Universaeles (UUIDs) excepto si tienes una buena razón para no hacerlo. No uses identificadores que no son únicos entre instancias del servicio o con otros recursos del servicio, especialmente identificadores auto-incrementales.
 
-Render UUIDs in downcased `8-4-4-4-12` format, e.g.:
+Presenta los UUIDs en minusculas, en formato `8-4-4-4-12`, p.e.:
 
 ```
 "id": "01234567-89ab-cdef-0123-456789abcdef"
 ```
 
-#### Provide standard timestamps
+#### Proporcionar fechas y horas (timestamps) estándar
 
-Provide `created_at` and `updated_at` timestamps for resources by default,
-e.g:
+Por defecto, incluye atributos de fecha-hora `created_at` y `updated_at` en tus recursos, p.e.:
 
 ```javascript
 {
@@ -256,21 +252,19 @@ e.g:
 }
 ```
 
-These timestamps may not make sense for some resources, in which case
-they can be omitted.
+Estas fechas/horas podrían no tener sentido en algunos recursos, en cuyo caso pueden ser omitidos.
 
-#### Use UTC times formatted in ISO8601
+#### Usar horas en UTC con formato ISO8601
 
-Accept and return times in UTC only. Render times in ISO8601 format,
-e.g.:
+Acepta y retorna fechas y horas sólo en formato UTC. Presenta las fechas utilizando el formato ISO8601, p.e.:
 
 ```
 "finished_at": "2012-01-01T12:00:00Z"
 ```
 
-#### Nest foreign key relations
+#### Anidar relaciones de clave foránea
 
-Serialize foreign key references with a nested object, e.g.:
+Serializa las relaciones de clave foránea usando objetos anidados, p.e.:
 
 ```javascript
 {
@@ -282,7 +276,7 @@ Serialize foreign key references with a nested object, e.g.:
 }
 ```
 
-Instead of e.g.:
+En lugar de, p.e.:
 
 ```javascript
 {
@@ -292,9 +286,7 @@ Instead of e.g.:
 }
 ```
 
-This approach makes it possible to inline more information about the
-related resource without having to change the structure of the response
-or introduce more top-level response fields, e.g.:
+Este enfoque hace posible incluir más información del recurso relacionado sin tener que cambiar la estructura de la respuesta o introducir más atributos de primer nivel, p.e.:
 
 ```javascript
 {
@@ -308,18 +300,13 @@ or introduce more top-level response fields, e.g.:
 }
 ```
 
-#### Generate structured errors
+#### Generar errores estructurados
 
-Generate consistent, structured response bodies on errors. Include a
-machine-readable error `id`, a human-readable error `message`, and
-optionally a `url` pointing the client to further information about the
-error and how to resolve it, e.g.:
+En caso de error, genera cuerpos de respuesta consistentes y estructurados. Incluye identificadores de error para su procesado, mensajes error para usuarios y, opcionalmente, una `url` para que el cliente pueda obtener más información sobre el error y sobre cómo resolverlo, p.e.:
 
 ```
 HTTP/1.1 429 Too Many Requests
-```
 
-```json
 {
   "id":      "rate_limit",
   "message": "Account reached its API rate limit.",
@@ -327,24 +314,18 @@ HTTP/1.1 429 Too Many Requests
 }
 ```
 
-Document your error format and the possible error `id`s that clients may
-encounter.
+Documenta tu formato de error y los identificadores de error que los clientes pueden recibir.
 
-#### Show rate limit status
+#### Mostrar el estado del límite de peticiones
 
-Rate limit requests from clients to protect the health of the service
-and maintain high service quality for other clients. You can use a
-[token bucket algorithm](http://en.wikipedia.org/wiki/Token_bucket) to
-quantify request limits.
+Limita el consumo de las peticiones de los clientes para asegurar la salud de tu servicio y para mantener un nivel de calidad alto para otros clientes.  Puedes usar un algoritmo como [token bucket](http://en.wikipedia.org/wiki/Token_bucket) para calcular los límites de las peticiones.
 
-Return the remaining number of request tokens with each request in the
-`RateLimit-Remaining` response header.
+Retorna el número de peticiones restantes en la cabecera de respuesta
+`RateLimit-Remaining`.
 
-#### Keep JSON minified in all responses
+#### Mantener los JSON minificados en todas las respuestas
 
-Extra whitespace adds needless response size to requests, and many
-clients for human consumption will automatically "prettify" JSON
-output. It is best to keep JSON responses minified e.g.:
+Los espacios extra incrementan innecesariamente el tamaño de las respuestas y muchos clientes para desarrolladores "maquillarán" (_N.T. prettify_) las respuestas JSON automaticamente. Así que es mejor que las respuestas JSON estén minificadas, p.e.:
 
 ```json
 {"beta":false,"email":"alice@heroku.com","id":"01234567-89ab-cdef-0123-456789abcdef","last_login":"2012-01-01T12:00:00Z","created_at":"2012-01-01T12:00:00Z","updated_at":"2012-01-01T12:00:00Z"}
@@ -363,9 +344,7 @@ Instead of e.g.:
 }
 ```
 
-You may consider optionally providing a way for clients to retrieve 
-more verbose response, either via a query parameter (e.g. `?pretty=true`)
-or via an `Accept` header param (e.g.
+Podrías ofrecer un método opcional para que los clientes recuperen respuestas más completas, ya sea a través de un parámetro (p.e. `?pretty=true`) o en la cabecera `Accept` (p.e.
 `Accept: application/vnd.heroku+json; version=3; indent=4;`).
 
 ### Artifacts

--- a/README.md
+++ b/README.md
@@ -182,18 +182,16 @@ p.e.
 /runs/{run_id}/actions/stop
 ```
 
-#### Downcase paths and attributes
+#### Utilizar minúsculas para rutas y atributos
 
-Use downcased and dash-separated path names, for alignment with
-hostnames, e.g:
+Usa nombres de rutas en minúsculas y separados por guión (-), para que sea igual que los nombres de dominio, p.e.:
 
 ```
 service-api.com/users
 service-api.com/app-setups
 ```
 
-Downcase attributes as well, but use underscore separators so that
-attribute names can be typed without quotes in JavaScript, e.g.:
+Para los atributos, utiliza también minúscular, pero usa guión bajo (_) para que los nombres de atributos puedan ser tecleados sin comillas en JavaScript, p.e.:
 
 ```
 service_class: "first"

--- a/README.md
+++ b/README.md
@@ -49,24 +49,18 @@ Agradecemos también [contribuciones](CONTRIBUTING.md) a la versión inglesa de 
 
 #### Separa responsabilidades
 
-Mientras diseñas, simplifica las cosas al máximo separando las responsabilidades de las diferentes partes del ciclo de petición y respuesta. Mantener reglas sencillas en esto te permite enfocarte en problemas mayores y más complejos.
+Mientras diseñas, simplifica al máximo separando las responsabilidades de las diferentes partes del ciclo de petición y respuesta. Mantener reglas sencillas en esto te permite enfocarte en problemas mayores y más complejos.
 
 Las peticiones y respuestas se realizarán para obtener un recurso o colección en concreto. Usa la ruta (_N.T. el path_) para especificar la entidad, el cuerpo para transferir los contenidos y las cabeceras para especificar metadatos. Los parámetros (_N.T. query params_) pueden ser usados como un medio de pasar información de cabecera en casos extremos, pero es preferible usar las cabeceras ya que son más flexibles y pueden transmitir información más variada.
 
-#### Require Secure Connections
+#### Conexiones seguras requeridas
 
-Require secure connections with TLS to access the API, without exception.
-It’s not worth trying to figure out or explain when it is OK to use TLS
-and when it’s not. Just require TLS for everything.
+Haz requerido el acceso seguro al API usando TLS, sin excepciones.
+No merece la pena intentar averiguar o explicar cuando se debe permitir acceso con TLS y cuando no. Haz obligatorio TLS para todo.
 
-Ideally, simply reject any non-TLS requests by not responding to requests for
-http or port 80 to avoid any insecure data exchange. In environments where this
-is not possible, respond with `403 Forbidden`.
+Idealmente, rechaza cualquier petición sin TLS sin responder a peticiones HTTP o al puerto 80, y así evitar cualquier intercambio de información insegura. En entornos en los que esto no sea posible, retorna con `403 Forbidden`.
 
-Redirects are discouraged since they allow sloppy/bad client behaviour without
-providing any clear gain.  Clients that rely on redirects double up on
-server traffic and render TLS useless since sensitive data will already
- have been exposed during the first call.
+Las redirecciones están desaconsejadas ya que permiten a los clientes tener comportamientos incorrectos/chapuceros sin ofrecer ninguna ventaja clara. Los clientes que dependen de las redirecciones duplican el tráfico del servidor and hacen que el TLS sea inutil ya que la información sensible ya ha sido expuesta durante la primera llamada.
 
 #### Require Versioning in the Accepts Header
 

--- a/README.md
+++ b/README.md
@@ -82,13 +82,9 @@ Incluye una cabecera `ETag` en todas las respuestas, identificando la versión e
 
 Incluye una cabecear `Request-Id` en cada respuesta del API, junto con un valor UUID. _Logueando_ estos valores en el cliente, en el servidor y cualquier otro servicio de apoyo, se ofrece un mecanismo para _tracear_, diagnosticar y depurar las peticiones.
 
-#### Divide Large Responses Across Requests with Ranges
+#### Dividir respuestas largas en varias peticiones usando rangos
 
-Large responses should be broken across multiple requests using `Range` headers
-to specify when more data is available and how to retrieve it. See the
-[Heroku Platform API discussion of Ranges](https://devcenter.heroku.com/articles/platform-api-reference#ranges)
-for the details of request and response headers, status codes, limits,
-ordering, and iteration.
+Las respuestas largas deben ser troceadas en múltiples peticiones usando la cabecera `Range` para especificar cuando están disponibles más datos y cómo recuperarlos. Consulta en [el debate sobre rangos (en inglés)](https://devcenter.heroku.com/articles/platform-api-reference#ranges) los detalles sobre las cabeceras de las peticiones y respuestas, los códigos de estado, límites, ordenación e iteración.
 
 ### Requests
 

--- a/README.md
+++ b/README.md
@@ -162,23 +162,21 @@ $ curl -X POST https://service.com/apps \
 }
 ```
 
-#### Use consistent path formats
+#### Usar formatos de ruta consistentes
 
-##### Resource names
+##### Nombre de recurso
 
-Use the plural version of a resource name unless the resource in question is a singleton within the system (for example, in most systems a given user would only ever have one account). This keeps it consistent in the way you refer to particular resources.
+Usa nombres de recurso en plural excepto si el recurso que estás nombrando es único (_N.T. singleton_) en el sistema (por ejemplo, en la mayoría de los sistemas un usuario dado sólo puede tener una cuenta). Esto permite que la forma de acceder a un recurso en particular sea consistente.
 
-##### Actions
+##### Acciones
 
-Prefer endpoint layouts that don’t need any special actions for
-individual resources. In cases where special actions are needed, place
-them under a standard `actions` prefix, to clearly delineate them:
+Son preferibles esquemas de llamada (_N.T. endpoint layouts_) que no necesiten ninguna acción especial para recursos individuales. En aquellos casos donde se necesitan acciones especiales, ponlas tras el prefijo estándar `actions`, para diferenciarlas claramente:
 
 ```
 /resources/:resource/actions/:action
 ```
 
-e.g.
+p.e.
 
 ```
 /runs/{run_id}/actions/stop

--- a/README.md
+++ b/README.md
@@ -78,11 +78,9 @@ Accept: application/vnd.heroku+json; version=3
 
 Incluye una cabecera `ETag` en todas las respuestas, identificando la versión específica del recurso retornado. Esto permite a los usuarios cachear recursos y usar peticiones con este valor en la cabecera `If-None-Match` para especificar si la caché debe ser actualizada.
 
-#### Provide Request-Ids for Introspection
+#### Proporcionar identificadores de petición para introspección
 
-Include a `Request-Id` header in each API response, populated with a
-UUID value. By logging these values on the client, server and any backing
-services, it provides a mechanism to trace, diagnose and debug requests.
+Incluye una cabecear `Request-Id` en cada respuesta del API, junto con un valor UUID. _Logueando_ estos valores en el cliente, en el servidor y cualquier otro servicio de apoyo, se ofrece un mecanismo para _tracear_, diagnosticar y depurar las peticiones.
 
 #### Divide Large Responses Across Requests with Ranges
 

--- a/README.md
+++ b/README.md
@@ -197,12 +197,9 @@ Para los atributos, utiliza también minúscular, pero usa guión bajo (_) para 
 service_class: "first"
 ```
 
-#### Support non-id dereferencing for convenience
+#### Soportar referencias por atributos no-identificadores como ayuda
 
-In some cases it may be inconvenient for end-users to provide IDs to
-identify a resource. For example, a user may think in terms of a Heroku
-app name, but that app may be identified by a UUID. In these cases you
-may want to accept both an id or name, e.g.:
+En algunos casos, puede ser conveniente para los usuarios finales ofrecer identificadores para acceder a recursos. Por ejemplo, un usuario puede pensar en los nombres de las apps en Heroku, pero una app puede estar identificada por un UUID. En estos casos, podrías aceptar tanto el identificador como el nombre, p.e.:
 
 ```bash
 $ curl https://service.com/apps/{app_id_or_name}
@@ -210,7 +207,7 @@ $ curl https://service.com/apps/97addcf0-c182
 $ curl https://service.com/apps/www-prod
 ```
 
-Do not accept only names to the exclusion of IDs.
+No aceptes sólo nombres omitiendo los identificadores.
 
 #### Minimize path nesting
 

--- a/README.md
+++ b/README.md
@@ -86,37 +86,30 @@ Incluye una cabecear `Request-Id` en cada respuesta del API, junto con un valor 
 
 Las respuestas largas deben ser troceadas en múltiples peticiones usando la cabecera `Range` para especificar cuando están disponibles más datos y cómo recuperarlos. Consulta en [el debate sobre rangos (en inglés)](https://devcenter.heroku.com/articles/platform-api-reference#ranges) los detalles sobre las cabeceras de las peticiones y respuestas, los códigos de estado, límites, ordenación e iteración.
 
-### Requests
+### Peticiones
 
-#### Return appropriate status codes
+#### Retornar códigos de estado apropiados
 
-Return appropriate HTTP status codes with each response. Successful
-responses should be coded according to this guide:
+Retorna códigos de estado HTTP apropiados para cada respuesta. Las respuetas con éxito deben retornar códigos según la siguiente guía:
 
-* `200`: Request succeeded for a `GET` call, for a `DELETE` or
-  `PATCH` call that completed synchronously, or for a `PUT` call that
-  synchronously updated an existing resource
-* `201`: Request succeeded for a `POST` call that completed
-  synchronously, or for a `PUT` call that synchronously created a new
-  resource
-* `202`: Request accepted for a `POST`, `PUT`, `DELETE`, or `PATCH` call that
-  will be processed asynchronously
-* `206`: Request succeeded on `GET`, but only a partial response
-  returned: see [above on ranges](#divide-large-responses-across-requests-with-ranges)
+* `200`: Petición exitosa para una llamada `GET`, `DELETE` o
+  `PATCH` que se completó de forma síncrona, o para una llamada `PUT` que actualizó un recurso existente de forma síncrona.
+* `201`: Petición exitosa para una llamada `POST` que se completó de forma síncrona, o para una llamada `PUT` que creó un nuevo recurso de forma síncrona.
+* `202`: Petición aceptada para una llamada `POST`, `PUT`, `DELETE`, o `PATCH` que será procesada de forma asíncrona.
+* `206`: Petición exitosa para una llamada `GET`, pero que sólo retorna una respuesta parcial: ver [sección sobre respuestas largas](#dividir-respuestas-largas-en-varias-peticiones-usando-rangos).
 
-Pay attention to the use of authentication and authorization error codes:
+Presta atención al uso de código de error de autenticación y autorización:
 
-* `401 Unauthorized`: Request failed because user is not authenticated
-* `403 Forbidden`: Request failed because user does not have authorization to access a specific resource
+* `401 Unauthorized`: Petición fallida porque el usuario no está autenticado.
+* `403 Forbidden`: Petición fallida porque el usuario no tiene autorización para acceder al un recurso en concreto.
 
-Return suitable codes to provide additional information when there are errors:
+Retorna códigos adecuados para ofrecer información adicional cuando ocurran errores:
 
-* `422 Unprocessable Entity`: Your request was understood, but contained invalid parameters
-* `429 Too Many Requests`: You have been rate-limited, retry later
-* `500 Internal Server Error`: Something went wrong on the server, check status site and/or report the issue
+* `422 Unprocessable Entity`: Tu petición es correcta, pero contiene parámetros inválidos.
+* `429 Too Many Requests`: Has superado el límite de consumo. Inténtalo de nuevo más tarde.
+* `500 Internal Server Error`: Algo falló en el servidor. Comprueba el estado del sitio y/o reporta la incidencia.
 
-Refer to the [HTTP response code spec](https://tools.ietf.org/html/rfc7231#section-6)
-for guidance on status codes for user error and server error cases.
+Consulta la [especificación de códigos de respuesta HTTP](https://tools.ietf.org/html/rfc7231#section-6) para una guía sobre los códigos de estado para errores de usuario o de servidor.
 
 #### Provide full resources where available
 

--- a/README.md
+++ b/README.md
@@ -347,64 +347,54 @@ Instead of e.g.:
 Podrías ofrecer un método opcional para que los clientes recuperen respuestas más completas, ya sea a través de un parámetro (p.e. `?pretty=true`) o en la cabecera `Accept` (p.e.
 `Accept: application/vnd.heroku+json; version=3; indent=4;`).
 
-### Artifacts
+### Artefactos
 
-#### Provide machine-readable JSON schema
+#### Proporcionar un esquema de JSON procesable
 
-Provide a machine-readable schema to exactly specify your API. Use
-[prmd](https://github.com/interagent/prmd) to manage your schema, and ensure
-it validates with `prmd verify`.
+Proporciona un esquema procesable (_machine-readable_) para especificar con exactitud el uso de tu API. Usa [prmd](https://github.com/interagent/prmd) para gestionar tu esquema, y asegúrate que es válido usando `prmd verify`.
 
-#### Provide human-readable docs
+#### Proporcionar docmentación para desarrolladores
 
-Provide human-readable documentation that client developers can use to
-understand your API.
+Proporciona una documentación para los desarrolladores puedan usar para entender tu API.
 
-If you create a schema with prmd as described above, you can easily
-generate Markdown docs for all endpoints with with `prmd doc`.
+Si creas un esquema con `prmd` como hemos dicho antes, puedes generar fácilmente documentos Markdown para todos tus servicios (_endpoints_) usando `prmd doc`.
 
-In addition to endpoint details, provide an API overview with
-information about:
+Además de los detalles de los servicios, ofrece un resumen de tu API con información sobre:
 
-* Authentication, including acquiring and using authentication tokens.
-* API stability and versioning, including how to select the desired API
-  version.
-* Common request and response headers.
-* Error serialization format.
-* Examples of using the API with clients in different languages.
+* Autenticacaión, incluyendo obtención y uso de tokens de autenticación.
+* Estabilidad y versionado del API, incluyendo cómo usar una versión específica del API.
+* Cabeceras de petición y respuesta genéricas.
+* Formato de respuestas de error.
+* Ejemplos de uso del API con clientes en distintos lenguajes.
 
-#### Provide executable examples
+#### Proporcionar ejemplos ejecutables
+
+Ofrece ejemplos ejecutables que los usuarios puedan probar directamente en sus terminales para ver las llamadas al API en funcionamiento.
 
 Provide executable examples that users can type directly into their
-terminals to see working API calls. To the greatest extent possible,
-these examples should be usable verbatim, to minimize the amount of
-work a user needs to do to try the API, e.g.:
+terminals to see working API calls. En la medida de lo posible, estos ejemplos deben ser utilizables tal cual, para minimizar la cantidad de trabajo necesario para probar el API, p.e.:
 
 ```bash
 $ export TOKEN=... # acquire from dashboard
 $ curl -is https://$TOKEN@service.com/users
 ```
 
-If you use [prmd](https://github.com/interagent/prmd) to generate Markdown
-docs, you will get examples for each endpoint for free.
+Si usas [prmd](https://github.com/interagent/prmd) para generar documentación en Markdown, tendrás ejemplos para cada servicio sin esfuerzo.
 
-#### Describe stability
+#### Describir la estabilidad
 
-Describe the stability of your API or its various endpoints according to
-its maturity and stability, e.g. with prototype/development/production
-flags.
+Describe la estabilidad de tu API o sus servicios en función de su madurez y estabilidad, por ejemplo con etiquetas prototipo/desarrollo/producción.
 
-See the [Heroku API compatibility policy](https://devcenter.heroku.com/articles/api-compatibility-policy)
-for a possible stability and change management approach.
+Ver la [política de compatibilidad del API de Heroku](https://devcenter.heroku.com/articles/api-compatibility-policy)
+para ver un posible enfoque de estabilidad y gestión del cambio.
 
-Once your API is declared production-ready and stable, do not make
-backwards incompatible changes within that API version. If you need to
-make backwards-incompatible changes, create a new API with an
-incremented version number.
+Una vez que tu API está declarada como lista para producción y estable, no hagas cambios incompatibles en una misma versión del API. Si necesitas hacer cambios incompatibles, crea una nueva API con un número de versión superior.
 
 
-### Translations
- * [Korean version](https://github.com/yoondo/http-api-design) (based on [f38dba6](https://github.com/interagent/http-api-design/commit/f38dba6fd8e2b229ab3f09cd84a8828987188863)), by [@yoondo](https://github.com/yoondo/)
- * [Simplified Chinese version](https://github.com/ZhangBohan/http-api-design-ZH_CN) (based on [337c4a0](https://github.com/interagent/http-api-design/commit/337c4a05ad08f25c5e232a72638f063925f3228a)), by [@ZhangBohan](https://github.com/ZhangBohan/)
- * [Traditional Chinese version](https://github.com/kcyeu/http-api-design) (based on [232f8dc](https://github.com/interagent/http-api-design/commit/232f8dc6a941d0b25136bf64998242dae5575f66)), by [@kcyeu](https://github.com/kcyeu/)
+### Traducciones
+
+ * [Versión original (inglés)](https://github.com/interagent/http-api-design/commit/2a74f45b9afaf6c951352f36c3a4e1b0418ed10b)
+ * [Versión en coreano](https://github.com/yoondo/http-api-design) (a partir de [f38dba6](https://github.com/interagent/http-api-design/commit/f38dba6fd8e2b229ab3f09cd84a8828987188863)), realizada por [@yoondo](https://github.com/yoondo/)
+ * [Versión en chino simplificado](https://github.com/ZhangBohan/http-api-design-ZH_CN) (a partir de [337c4a0](https://github.com/interagent/http-api-design/commit/337c4a05ad08f25c5e232a72638f063925f3228a)), realizada por [@ZhangBohan](https://github.com/ZhangBohan/)
+ * [Versión en chino traducional](https://github.com/kcyeu/http-api-design) (a partir de [232f8dc](https://github.com/interagent/http-api-design/commit/232f8dc6a941d0b25136bf64998242dae5575f66)), realizada por [@kcyeu](https://github.com/kcyeu/)
 

--- a/README.md
+++ b/README.md
@@ -142,11 +142,9 @@ Content-Type: application/json;charset=utf-8
 {}
 ```
 
-#### Accept serialized JSON in request bodies
+#### Aceptar JSON serializado en el cuerpo de las peticiones
 
-Accept serialized JSON on `PUT`/`PATCH`/`POST` request bodies, either
-instead of or in addition to form-encoded data. This creates symmetry
-with JSON-serialized response bodies, e.g.:
+Soporta JSON serializados en los cuerpos de las peticiones `PUT`/`PATCH`/`POST`, tanto en lugar de, como junto a datos de formularios HTML. Esto es equivalente a los cuerpos de las respuestas con JSON serializado, p.e.:
 
 ```bash
 $ curl -X POST https://service.com/apps \

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Introducción
 
-Esta guía describe un conjunto de buenas prácticas para el diseño de APIs HTTP+JSON originalmente extraído del trabajo en el API de la [plataforma Heroku](https://devcenter.heroku.com/articles/platform-api-reference).
+Esta guía describe una serie de buenas prácticas para el diseño de APIs HTTP+JSON originalmente extraído del trabajo en el API de la [plataforma Heroku](https://devcenter.heroku.com/articles/platform-api-reference).
 
 Esta guía incluye añadidos a ese API y también sirve de guía para nuevas APIs internas en Heroku. Esteramos que sea de interés a los diseñadores de APIs que no son de Heroku.
 
@@ -13,37 +13,37 @@ Asumimos que los conceptos básicos de APIs HTTP+JSON son familiares para tí, a
 
 Agradecemos también [contribuciones](CONTRIBUTING.md) a la versión inglesa de esta guía o a su traducción al castellano.
 
-## Contents
+## Contenidos
 
-* [Foundations](#foundations)
-  *  [Separate Concerns](#separate-concerns)
-  *  [Require Secure Connections](#require-secure-connections)
-  *  [Require Versioning in the Accepts Header](#require-versioning-in-the-accepts-header)
-  *  [Support ETags for Caching](#support-etags-for-caching)
-  *  [Provide Request-Ids for Introspection](#provide-request-ids-for-introspection)
-  *  [Divide Large Responses Across Requests with Ranges](#divide-large-responses-across-requests-with-ranges)
-* [Requests](#requests)
-  *  [Return appropriate status codes](#return-appropriate-status-codes)
-  *  [Provide full resources where available](#provide-full-resources-where-available)
-  *  [Accept serialized JSON in request bodies](#accept-serialized-json-in-request-bodies)
-  *  [Use consistent path formats](#use-consistent-path-formats)
-    *  [Downcase paths and attributes](#downcase-paths-and-attributes)
-    *  [Support non-id dereferencing for convenience](#support-non-id-dereferencing-for-convenience)
-    *  [Minimize path nesting](#minimize-path-nesting)
-* [Responses](#responses)
-  *  [Provide resource (UU)IDs](#provide-resource-uuids)
-  *  [Provide standard timestamps](#provide-standard-timestamps)
-  *  [Use UTC times formatted in ISO8601](#use-utc-times-formatted-in-iso8601)
-  *  [Nest foreign key relations](#nest-foreign-key-relations)
-  *  [Generate structured errors](#generate-structured-errors)
-  *  [Show rate limit status](#show-rate-limit-status)
-  *  [Keep JSON minified in all responses](#keep-json-minified-in-all-responses)
-* [Artifacts](#artifacts)
-  *  [Provide machine-readable JSON schema](#provide-machine-readable-json-schema)
-  *  [Provide human-readable docs](#provide-human-readable-docs)
-  *  [Provide executable examples](#provide-executable-examples)
-  *  [Describe stability](#describe-stability)
-* [Translations](#translations)
+* [Fundamentos](#fundamentos)
+  *  [Separar responsabilidades](#separar-responsabilidades)
+  *  [Conexiones seguras requeridas](#conexiones-seguras-requeridas)
+  *  [Versionado en la cabecera Accepts requerido](#versionado-en-la-cabecera-accepts-requerido)
+  *  [Soportar ETags para cacheado](#soportar-etags-para-cacheado)
+  *  [Proporcionar identificadores de petición para introspección](#Proporcionar-identificadores-de-petición-para-introspeccion)
+  *  [Dividir respuestas largas en varias peticiones usando rangos](#dividir-respuestas-largas-en-varias-peticiones-usando-rangos)
+* [Peticiones](#peticiones)
+  *  [Retornar códigos de estado apropiados](#retornar-codigos-de-estado-apropiados)
+  *  [Proporcionar recursos completos si están disponibles](#proporcionar-recursos-completos-si-estan-disponibles)
+  *  [Aceptar JSON serializado en el cuerpo de las peticiones](#aceptar-json-serializado-en-el-cuerpo-de-las-peticiones)
+  *  [Usar formatos de ruta consistentes](#usar-formatos-de-ruta-consistentes)
+    *  [Utilizar minúsculas para rutas y atributos](#utilizar-minusculas-para-rutas-y-atributos)
+    *  [Soportar referencias por atributos no-identificadores como ayuda](#soportar-referencias-por-atributos-no-identificadores-como-ayuda)
+    *  [Minimizar anidado de rutas](#minimizar-anidad-de-rutas)
+* [Respuestas](#respuestas)
+  *  [Proporcionar identificadores únicos (UUIDs) de recursos](#proporcionar-identificadores-unicos-uuids-de-recursos)
+  *  [Proporcionar fechas y horas (timestamps) estándar](#proporcionar-fechas-y-horas-timestamps-estandar)
+  *  [Usar horas en UTC formateadas usando ISO8601](#usar-horas-en-utc-formateadas-usando-ISO8601)
+  *  [Anidar relaciones de clave foránea](#anidar-relaciones-de-clave-foranea)
+  *  [Generar errores estructurados](#generar-errores-estructurados)
+  *  [Mostrar el estado del límite de peticiones](#mostrar-el-estado-del-limite-de-peticiones)
+  *  [Mantener los JSON minificados en todas las respuestas](#mantener-los-json-minificados-en-todas-las-respuestas)
+* [Artefactos](#artifactos)
+  *  [Proporcionar un esquema de JSON procesable](#proporcionar-un-esquema-de-json-procesable)
+  *  [Proporcionar docmentación para desarrolladores](#proporcionar-docmentacion-para-desarrolladores)
+  *  [Proporcionar ejemplos ejecutables](#proporcionar-ejemplos-ejecutables)
+  *  [Describir la estabilidad](#describir-la-estabilidad)
+* [Traducciones](#tranducciones)
 
 ### Foundations
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Agradecemos también [contribuciones](CONTRIBUTING.md) a la versión inglesa de 
 * [Fundamentos](#fundamentos)
   *  [Separar responsabilidades](#separar-responsabilidades)
   *  [Conexiones seguras requeridas](#conexiones-seguras-requeridas)
-  *  [Versionado en la cabecera Accepts requerido](#versionado-en-la-cabecera-accepts-requerido)
+  *  [Versionado con la cabecera Accepts requerido](#versionado-con-la-cabecera-accepts-requerido)
   *  [Soportar ETags para cacheado](#soportar-etags-para-cacheado)
   *  [Proporcionar identificadores de petición para introspección](#Proporcionar-identificadores-de-petición-para-introspeccion)
   *  [Dividir respuestas largas en varias peticiones usando rangos](#dividir-respuestas-largas-en-varias-peticiones-usando-rangos)
@@ -45,19 +45,13 @@ Agradecemos también [contribuciones](CONTRIBUTING.md) a la versión inglesa de 
   *  [Describir la estabilidad](#describir-la-estabilidad)
 * [Traducciones](#tranducciones)
 
-### Foundations
+### Fundamentos
 
-#### Separate Concerns
+#### Separa responsabilidades
 
-Keep things simple while designing by separating the concerns between the
-different parts of the request and response cycle. Keeping simple rules here
-allows for greater focus on larger and harder problems.
+Mientras diseñas, simplifica las cosas al máximo separando las responsabilidades de las diferentes partes del ciclo de petición y respuesta. Mantener reglas sencillas en esto te permite enfocarte en problemas mayores y más complejos.
 
-Requests and responses will be made to address a particular resource or
-collection. Use the path to indicate identity, the body to transfer the
-contents and headers to communicate metadata. Query params may be used as a
-means to pass header information also in edge cases, but headers are preferred
-as they are more flexible and can convey more diverse information.
+Las peticiones y respuestas se realizarán para obtener un recurso o colección en concreto. Usa la ruta (_N.T. el path_) para especificar la entidad, el cuerpo para transferir los contenidos y las cabeceras para especificar metadatos. Los parámetros (_N.T. query params_) pueden ser usados como un medio de pasar información de cabecera en casos extremos, pero es preferible usar las cabeceras ya que son más flexibles y pueden transmitir información más variada.
 
 #### Require Secure Connections
 


### PR DESCRIPTION
en el segundo parrafo se encuentra escrito lo siguiente:

Esta guía incluye añadidos a ese API y también sirve de guía para nuevas APIs internas en Heroku. Esteramos que sea de interés a los diseñadores de APIs que no son de Heroku.

luego del punto seguido dice `Esteramos` y debería decir `Esperamos`
