### PR TITLE
200 and 201 and location headers

### DIFF
--- a/en/responses/return-appropriate-status-codes.md
+++ b/en/responses/return-appropriate-status-codes.md
@@ -3,10 +3,11 @@
 Return appropriate HTTP status codes with each response. Successful
 responses should be coded according to this guide:
 
-* `200`: Request succeeded for a `GET` call, for a `DELETE` or
+* `200`: Request succeeded for a `GET` call, for a `POST`, `DELETE` or
   `PATCH` call that completed synchronously, or for a `PUT` call that
   synchronously updated an existing resource
-* `201`: Request succeeded for a `POST` call that completed
+* `201`: Request succeeded for a `POST` used for creation or `PUT` 
+  callcall that completed
   synchronously, or for a `PUT` call that synchronously created a new
   resource
 * `202`: Request accepted for a `POST`, `PUT`, `DELETE`, or `PATCH` call that

--- a/en/responses/return-appropriate-status-codes.md
+++ b/en/responses/return-appropriate-status-codes.md
@@ -6,10 +6,9 @@ responses should be coded according to this guide:
 * `200`: Request succeeded for a `GET` call, for a `POST`, `DELETE` or
   `PATCH` call that completed synchronously, or for a `PUT` call that
   synchronously updated an existing resource
-* `201`: Request succeeded for a `POST` used for creation or `PUT` 
-  callcall that completed
-  synchronously, or for a `PUT` call that synchronously created a new
-  resource
+* `201`: Request succeeded for a `POST` or a `PUT` call that synchronously created a new
+  resource. Don't forget the Location header to point to the newly created resource,
+  it is usefull for `POST` because the target resource is not the created resource.
 * `202`: Request accepted for a `POST`, `PUT`, `DELETE`, or `PATCH` call that
   will be processed asynchronously
 * `206`: Request succeeded on `GET`, but only a partial response


### PR DESCRIPTION
It is useful to return Location header post POST creation, because the caller made the request on the POST handler, not the created resource. 
With PUT, the request is made on the target resource, so Lcation header can be omitted.