### PR TITLE
Add guidance on providing standard response types

### DIFF
--- a/en/SUMMARY.md
+++ b/en/SUMMARY.md
@@ -20,6 +20,7 @@
   * [Provide full resources where available](responses/provide-full-resources-where-available.md)
   * [Provide resource (UU)IDs](responses/provide-resource-uuids.md)
   * [Provide standard timestamps](responses/provide-standard-timestamps.md)
+  * [Provide standard response types](responses/provide-standard-response-types.md)
   * [Use UTC times formatted in ISO8601](responses/use-utc-times-formatted-in-iso8601.md)
   * [Nest foreign key relations](responses/nest-foreign-key-relations.md)
   * [Generate structured errors](responses/generate-structured-errors.md)

--- a/en/responses/provide-standard-response-types.md
+++ b/en/responses/provide-standard-response-types.md
@@ -1,7 +1,77 @@
 #### Provide standard response types
 
-When a value is a array type, return an empty array rather than `NULL` when
-there are no values in the array.
+This document describes the acceptable values for each of JSON's basic data
+types.
+
+### String
+
+* Acceptable values:
+  * string
+  * `null`
+
+e.g:
+
+```javascript
+[
+  {
+    "description": "very descriptive description."
+  },
+  {
+    "description": null
+  },
+]
+```
+
+### Boolean
+
+* Acceptable values:
+  * true
+  * false
+
+e.g:
+
+```javascript
+[
+  {
+    "provisioned_licensese": true
+  },
+  {
+    "provisioned_licenses": false
+  },
+]
+```
+
+### Number
+
+* Acceptable values:
+  * number
+  * `null`
+
+Note: some JSON parsers will return numbers with a precision of over 15
+decimal places as strings. If you need precision greater than 15 decimals,
+always return a string for that value. If not, convert those strings to numbers
+so that consumers of the API always know what value type to expect.
+
+e.g:
+
+```javascript
+[
+  {
+    "average": 27.123
+  },
+  {
+    "average": 12.123456789012
+  },
+]
+```
+
+### Array
+
+* Acceptable values:
+  * array
+
+Note: Return an empty array rather than `NULL` when there are no values in the
+array.
 
 e.g:
 
@@ -9,23 +79,9 @@ e.g:
 [
   {
     "child_ids": [1, 2, 3, 4],
-    // ...
   },
   {
     "child_ids": [],
-    // ...
   }
 ]
 ```
-
-For all other values, the response type should always be the same basic type or
-`NULL`.
-
-For example, some JSON parsers will return numbers with a precision of over 15
-decimal places as strings. If you need precision greater than 15 decimals,
-always return a string for that value. If not, convert those strings to numbers
-so that consumers of the API always know what value type to expect.
-
-One exception to this rule is that it sometimes makes sense to return `NULL`
-rather than an "empty" value of the same basic type, such as `""` for a string
-or `0` for an integer.

--- a/en/responses/provide-standard-response-types.md
+++ b/en/responses/provide-standard-response-types.md
@@ -1,0 +1,31 @@
+#### Provide standard response types
+
+When a value is a array type, return an empty array rather than `NULL` when
+there are no values in the array.
+
+e.g:
+
+```javascript
+[
+  {
+    "child_ids": [1, 2, 3, 4],
+    // ...
+  },
+  {
+    "child_ids": [],
+    // ...
+  }
+]
+```
+
+For all other values, the response type should always be the same basic type or
+`NULL`.
+
+For example, some JSON parsers will return numbers with a precision of over 15
+decimal places as strings. If you need precision greater than 15 decimals,
+always return a string for that value. If not, convert those strings to numbers
+so that consumers of the API always know what value type to expect.
+
+One exception to this rule is that it sometimes makes sense to return `NULL`
+rather than an "empty" value of the same basic type, such as `""` for a string
+or `0` for an integer.

--- a/en/responses/provide-standard-response-types.md
+++ b/en/responses/provide-standard-response-types.md
@@ -85,3 +85,26 @@ e.g:
   }
 ]
 ```
+
+### Object
+
+* Acceptable values:
+  * object
+  * null
+
+e.g:
+
+```javascript
+[
+  {
+    "name": "service-production",
+    "owner": {
+      "id": "5d8201b0..."
+     }
+  },
+  {
+    "name": "service-staging",
+    "owner": null
+  }
+]
+```


### PR DESCRIPTION
* Returning an empty array rather than `NULL` helps consumers avoid
conditionals.
* Duck types FTW
* Except for `NULL`, I guess
* This came up when I learned that Oj parses BigDecimals as Strings.
Seemed like bad API design to sometimes return a Number and sometimes
return a String but this idea had not been articulated in the HTTP
Design Guide.